### PR TITLE
Port and ComputerName support

### DIFF
--- a/Functions/Send-DataDogEvent.ps1
+++ b/Functions/Send-DataDogEvent.ps1
@@ -19,6 +19,13 @@
     Priority of the event: normal or low
 .PARAMETER Tag
     List of tag definitions for the metric in "tagname:value" format
+.PARAMETER ComputerName
+    Optional - ComputerName (Hostname or IPaddress) of the
+    target statsd service
+        Default is 127.0.0.1 for localhost
+.PARAMETER Port
+    Optional - Port for the target statsd service
+        Default is 8125
 .EXAMPLE
     Send-DataDogEvent -Title 'My event' -Text 'Add any details' -Tag @("subsytem:my_test_tag1")
 #>
@@ -38,6 +45,10 @@ function Send-DataDogEvent {
         [string]$ComputerName=$(hostname),
 
         [Parameter()]
+        [ValidateRange(1,65535)]
+        [int]$Port=8125,
+
+        [Parameter()]
         [ValidateSet('normal','low')]
         [string]$Priority='normal',
 
@@ -51,5 +62,5 @@ function Send-DataDogEvent {
         [Parameter()]
         [string[]]$Tag=@()
     )
-    Send-StatsD "_e{$($Title.Length),$($Text.Length)}:$Title|$Text|h:$ComputerName|p:$Priority|t:$AlertType|#$([string]::Join(',',$Tag))"
+    Send-StatsD -Data "_e{$($Title.Length),$($Text.Length)}:$Title|$Text|h:$ComputerName|p:$Priority|t:$AlertType|#$([string]::Join(',',$Tag))" -ComputerName $ComputerName -Port $Port
 }

--- a/Functions/Send-DataDogMetric.ps1
+++ b/Functions/Send-DataDogMetric.ps1
@@ -17,8 +17,17 @@
         'Counter','Gauge','Histogram','Timer','Set'
 .PARAMETER Tag
     List of tag definitions for the metric in "tagname:value" format
+.PARAMETER ComputerName
+    Optional - ComputerName (Hostname or IPaddress) of the
+    target statsd service
+        Default is 127.0.0.1 for localhost
+.PARAMETER Port
+    Optional - Port for the target statsd service
+        Default is 8125
 .EXAMPLE
     Send-DataDogMetric -Type Histogram -Name 'command.duration' -Value 12 -Tag @("command:my_command_name")
+.EXAMPLE
+    Send-DataDogMetric -Type Gauge -Name 'random.value' -Value $randomvalue -ComputerName 192.168.0.1 -Port 8125
 #>
 function Send-DataDogMetric {
     [CmdletBinding()]
@@ -40,6 +49,10 @@ function Send-DataDogMetric {
         [string]$ComputerName=$(hostname),
 
         [Parameter()]
+        [ValidateRange(1,65535)]
+        [int]$Port=8125,
+
+        [Parameter()]
         [string]$SampleRate='1',
 
         [Parameter()]
@@ -52,5 +65,5 @@ function Send-DataDogMetric {
         'Set' { $ddType = 's' }
     }
     if (-Not $ddType) { Write-Error "$Type is not a valid metricstype" }
-    Send-StatsD "$($Name):$($Value)|$ddType|@$SampleRate|#$([string]::Join(',',$Tag))"
+    Send-StatsD -Data "$($Name):$($Value)|$ddType|@$SampleRate|#$([string]::Join(',',$Tag))" -ComputerName $ComputerName -Port $Port
 }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Send-DataDogEvent -Title "Failure Event" -Text 'Error details can come here' -Al
 
 # Send a Histogram metric for an example command duration
 Send-DataDogMetric -Type Histogram -Name 'command.duration' -Value 12 -Tag @("command:my_command_name")
+
+# Send a Gauge metric with value from variable to a given host and port
+Send-DataDogMetric -Type Gauge -Name 'random.value' -Value $randomvalue -ComputerName 192.168.0.1 -Port 8125
 ```
 
 ## Documentation


### PR DESCRIPTION
Please consider this PR, need it do use a given DataDog statsd instance. Otherwise nice module. :-)

Add example with Port and ComputerName in README.
Add support for Port and ComputerName.