### PR TITLE
Add Distribution metric type, -WhatIf support, few other changes

### DIFF
--- a/DogStatsD.psd1
+++ b/DogStatsD.psd1
@@ -10,7 +10,7 @@
 RootModule = 'DogStatsD.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.1.1'
+ModuleVersion = '1.0.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'a2c94f92-cfb1-4f8f-8cc8-7a77b2122b0d'

--- a/Functions/Send-DataDogEvent.ps1
+++ b/Functions/Send-DataDogEvent.ps1
@@ -50,9 +50,6 @@ function Send-DataDogEvent {
         [string]$Priority='normal',
 
         [Parameter()]
-        [string]$SourceType,
-
-        [Parameter()]
         [ValidateSet('info','success','warning','error')]
         [string]$AlertType='info',
 
@@ -71,7 +68,6 @@ function Send-DataDogEvent {
         $statsdParams.Port = $Port
     }
 
-    $statsdParams
     if ($PSCmdlet.ShouldProcess("Sending DataDog event: $data")) {
         Send-StatsD @statsdParams
     }

--- a/Functions/Send-StatsD.ps1
+++ b/Functions/Send-StatsD.ps1
@@ -42,24 +42,26 @@ function Send-StatsD {
         [int]$Port=8125
     )
 
-    Write-Verbose "Targeting $($ComputerName):$Port UDP endpoint.."
-    $UdpClient = New-Object System.Net.Sockets.UdpClient($ComputerName, $Port)
+    Process {
+        Write-Verbose "Targeting $($ComputerName):$Port UDP endpoint.."
+        $UdpClient = New-Object System.Net.Sockets.UdpClient($ComputerName, $Port)
 
-    try {
-        Write-Debug "Encoding data:`n$Data"
-        $bytes=[System.Text.Encoding]::ASCII.GetBytes($Data)
+        try {
+            Write-Debug "Encoding data:`n$Data"
+            $bytes=[System.Text.Encoding]::ASCII.GetBytes($Data)
 
-        Write-Debug "Sending Encoded Data: `n$bytes"
-        if ($PSCmdlet.ShouldProcess($ComputerName, "Sending $($bytes.Count) bytes.")) {
-            $sent=$UdpClient.Send($bytes,$bytes.length)
-            Write-Debug "Data Length sent: $sent"
+            Write-Debug "Sending Encoded Data: `n$bytes"
+            if ($PSCmdlet.ShouldProcess($ComputerName, "Sending $($bytes.Count) bytes.")) {
+                $sent=$UdpClient.Send($bytes,$bytes.length)
+                Write-Debug "Data Length sent: $sent"
+            }
+            $UdpClient.Close()
+        } catch {
+            Write-Error $_
+        } finally {
+            $UdpClient.Dispose()
         }
-        $UdpClient.Close()
-    } catch {
-        Write-Error $_
-    } finally {
-        $UdpClient.Dispose()
-    }
 
-    $UdpClient = $null
+        $UdpClient = $null
+    }
 }

--- a/Functions/Send-StatsD.ps1
+++ b/Functions/Send-StatsD.ps1
@@ -27,7 +27,7 @@
 #>
 
 function Send-StatsD {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         [parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [ValidateNotNullOrEmpty()]
@@ -36,7 +36,7 @@ function Send-StatsD {
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]$ComputerName='127.0.0.1',
-        
+
         [Parameter()]
         [ValidateRange(1,65535)]
         [int]$Port=8125
@@ -50,9 +50,10 @@ function Send-StatsD {
         $bytes=[System.Text.Encoding]::ASCII.GetBytes($Data)
 
         Write-Debug "Sending Encoded Data: `n$bytes"
-        $sent=$UdpClient.Send($bytes,$bytes.length)
-
-        Write-Debug "Data Length sent: $sent"
+        if ($PSCmdlet.ShouldProcess($ComputerName, "Sending $($bytes.Count) bytes.")) {
+            $sent=$UdpClient.Send($bytes,$bytes.length)
+            Write-Debug "Data Length sent: $sent"
+        }
         $UdpClient.Close()
     } catch {
         Write-Error $_

--- a/Tests/Module/ScriptAnalyzer.tests.ps1
+++ b/Tests/Module/ScriptAnalyzer.tests.ps1
@@ -1,9 +1,7 @@
 . (Join-Path $PSScriptRoot '../TestCommon.ps1')
 
 $scriptSources = Get-ChildItem -Path $script:FunctionPath -Filter '*.ps1' -Recurse
-$excludeRuleList = @(
-    'PSUseShouldProcessForStateChangingFunctions'
-)
+$excludeRuleList = @()
 
 if (-Not (Get-Module PSScriptAnalyzer -ListAvailable)) {
     try {


### PR DESCRIPTION
## Summary of Changes
* Add the `Distribution` metric type for `Send-DataDogMetric`
* Add `-WhatIf` support to `Send-StatsD`, `Send-DataDogMetric`, and `Send-DataDogEvent`
* Remove explicit default values for `-ComputerName` and `-Port` in the `*-DataDog*` commands, in favor of defining the default in one place (`Send-StatsD`)
* Remove the `-DateTime` and `-SourceType` parameters from `Send-DataDogEvent` (they were unused and undocumented)
* Added `Process {}` block to `Send-StatsD` (resolve pester warning)
* Remove Pester rule exclusion for not supporting `ShouldProcess` (since the functions now support it)
* Bumped version to 1.0.0.0

## Version reasoning
The `-Whatif` support and The `Distribution` addition is a new feature, but backwards compatible, so would have only needed a minor version update.

But the default param change is a (lightly) breaking change because the `Send-StatsD` default is `127.0.0.1` while the DD commands shelled out to `hostname` for their default. End result is probably the same, but the way it gets there is different and could possibly be different depending on your local networking configuration.

Also the removal of the `-DateTime` and `-SourceType` parameters is technically breaking because callers who were setting it before (even though it had no effect) would get a parameter binding error now.

So due to the above, went with a major version increase.