### PR TITLE
Add pipeline support to speed up large numbers of metrics

### DIFF
--- a/DogStatsD.psd1
+++ b/DogStatsD.psd1
@@ -10,7 +10,7 @@
 RootModule = 'DogStatsD.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0.0'
+ModuleVersion = '1.1.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'a2c94f92-cfb1-4f8f-8cc8-7a77b2122b0d'

--- a/Functions/Send-DataDogMetric.ps1
+++ b/Functions/Send-DataDogMetric.ps1
@@ -28,19 +28,29 @@
     Send-DataDogMetric -Type Histogram -Name 'command.duration' -Value 12 -Tag @("command:my_command_name")
 .EXAMPLE
     Send-DataDogMetric -Type Gauge -Name 'random.value' -Value $randomvalue -ComputerName 192.168.0.1 -Port 8125
+.EXAMPLE
+    1..20000 | Send-DataDogMetric -Type Counter -Name 'incrementing.value' -Value { $_ }
+.EXAMPLE
+    Get-AppStatistics | Send-DataDogMetric -Type Gauge -Name 'appco.active_users' -Value { $_.ActiveUsers }
+.EXAMPLE
+    Get-Process |
+        Send-DataDogMetric -Name 'server.process.handles' -Type Counter -Value { $_.Handles } -Tag { @("process:$($_.ProcessName)","pid:$($_.Id)") }
 #>
 function Send-DataDogMetric {
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('MetricName')]
         [ValidateNotNullOrEmpty()]
         [string]$Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('MetricValue')]
         [ValidateNotNullOrEmpty()]
         [string]$Value,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('MetricType')]
         [ValidateSet('Counter','Gauge','Histogram','Timer','Set','Distribution')]
         [string]$Type,
 
@@ -52,32 +62,50 @@ function Send-DataDogMetric {
         [ValidateRange(1,65535)]
         [int]$Port,
 
-        [Parameter()]
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [Alias('MetricSampleRate')]
         [string]$SampleRate='1',
 
-        [Parameter()]
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [Alias('MetricTag')]
+        [Alias('MetricTags')]
         [string[]]$Tag=@()
-
     )
-    $ddType = if ($Type -eq 'Timer') {
-        'ms'
-    }
-    else {
-        $Type.ToLower()[0]
+
+    Begin {
+        $statsdParams = @{
+            Verbose = $VerbosePreference -as [bool]
+            Debug = $DebugPreference -as [bool]
+        }
+        if ($ComputerName) {
+            $statsdParams.ComputerName = $ComputerName
+        }
+        if ($Port) {
+            $statsdParams.Port = $Port
+        }
+
+        # start a steppable pipeline for Send-StatsD so we can ensure we use a single UDP socket across the pipeline
+        $sendStatsD = { Send-StatsD @statsdParams }.GetSteppablePipeline($MyInvocation.CommandOrigin)
+        $sendStatsD.Begin($true)
     }
 
-    $data = "$($Name):$($Value)|$ddType|@$SampleRate|#$([string]::Join(',',$Tag))"
-    $statsdParams = @{
-        Data = $data
-    }
-    if ($ComputerName) {
-        $statsdParams.ComputerName = $ComputerName
-    }
-    if ($Port) {
-        $statsdParams.Port = $Port
+    Process {
+        $ddType = if ($Type -eq 'Timer') {
+            'ms'
+        }
+        else {
+            $Type.ToLower()[0]
+        }
+
+        $tagData = [string]::Join(',', $Tag)
+        $data = "${Name}:${Value}|${ddType}|@${SampleRate}|#${tagData}"
+
+        if ($PSCmdlet.ShouldProcess($data)) {
+            $sendStatsD.Process($data)
+        }
     }
 
-    if ($PSCmdlet.ShouldProcess("Sending DataDog metric: $data")) {
-        Send-StatsD @statsdParams
+    End {
+        $sendStatsD.End()
     }
 }

--- a/Functions/Send-StatsD.ps1
+++ b/Functions/Send-StatsD.ps1
@@ -42,10 +42,12 @@ function Send-StatsD {
         [int]$Port=8125
     )
 
-    Process {
+    Begin {
         Write-Verbose "Targeting $($ComputerName):$Port UDP endpoint.."
         $UdpClient = New-Object System.Net.Sockets.UdpClient($ComputerName, $Port)
+    }
 
+    Process {
         try {
             Write-Debug "Encoding data:`n$Data"
             $bytes=[System.Text.Encoding]::ASCII.GetBytes($Data)
@@ -55,13 +57,15 @@ function Send-StatsD {
                 $sent=$UdpClient.Send($bytes,$bytes.length)
                 Write-Debug "Data Length sent: $sent"
             }
-            $UdpClient.Close()
-        } catch {
-            Write-Error $_
-        } finally {
-            $UdpClient.Dispose()
         }
+        catch {
+            Write-Error $_
+        }
+    }
 
+    End {
+        $UdpClient.Close()
+        $UdpClient.Dispose()
         $UdpClient = $null
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ DogStatsD module provides a simple way to send events and metrics or other
 messages to [DataDog][datadog] from PowerShell via [DogStatsD][dogstatsd] UDP protocol.
 
 ## Installation
-DogStatsD is available via [PowerShellGallery][PowerShellGallery] and via
-[PsGet][psget], so you can simply install it with the following command:
+DogStatsD is available via [PowerShellGallery][PowerShellGallery], so you can simply install it with the following command:
 ```powershell
 Install-Module DogStatsD
 ```
@@ -28,6 +27,16 @@ Send-DataDogMetric -Type Histogram -Name 'command.duration' -Value 12 -Tag @("co
 
 # Send a Gauge metric with value from variable to a given host and port
 Send-DataDogMetric -Type Gauge -Name 'random.value' -Value $randomvalue -ComputerName 192.168.0.1 -Port 8125
+
+# Send lots of Counter metric values via the pipeline
+1..20000 | Send-DataDogMetric -Type Counter -Name 'incrementing.value' -Value { $_ }
+
+# Use the output of another command to provide values for a Gauge metric
+Get-AppStatistics | Send-DataDogMetric -Type Gauge -Name 'appco.active_users' -Value { $_.ActiveUsers }
+
+# Use input objects to generate tags and values for a Counter metric
+Get-Process |
+    Send-DataDogMetric -Name 'process.handles' -Type Counter -Value { $_.Handles } -Tag { @("process:$($_.ProcessName)","pid:$($_.Id)") }
 ```
 
 ## Documentation


### PR DESCRIPTION
## Changes
* Update the existing pipeline support in `Send-StatsD` to use a single `UDPClient` for the entire pipeline, instead creating and destroying one for each pipeline item
* Update `Send-DataDogMetric` to accept its parameters via pipeline object (by property name). This unlocks 2 things:
  * Using pipeline input to set all of the relevant parameters (via PowerShell's ability to use a scriptblock for any pipeline-bound param)
  * Use the new single `UDPClient` support in `Send-StatsD` to get the same performance benefits when sending lots of metrics.
* Add new pipeline examples to `Send-DataDogMetric` and include them in the README

## Speed Improvement
By using the pipeline this way, time taken was reduced significantly. Examples with 20 000 iterations:

**Not using pipeline: 12.946 seconds**
```powershell
Measure-Command -Expression { (1..20000).ForEach({ Send-DataDogMetric -Name 'a' -Type Counter -Tag @("ABC:$_") -Value $_ }) }
```

**Using pipeline: 3.898 seconds**
```powershell
Measure-Command -Expression { 1..20000 | Send-DataDogMetric -Name 'a' -Type Counter -Tag { @("ABC:$_") } -Value { $_ } }
```

For `Send-StatsD` directly:

**Not using pipeline: 9.104s**
```powershell
Measure-Command -Expression { (1..20000).ForEach({ Send-StatsD -Data $_ }) }
```

**Using pipeline: 2.642s**
```powershell
Measure-Command -Expression { 1..20000 | Send-StatsD }
```
---

I didn't update `Send-DataDogEvent` with pipeline support as it seemed like something that isn't likely to be called as often, but I don't use it myself (yet), so if that's desired I could add it in in another PR.